### PR TITLE
fix: jwt 토큰 내부에 user객체 수정

### DIFF
--- a/src/main/java/com/example/oneplusone/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/oneplusone/domain/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
             throw new BaseException(ErrorCode.INVALID_PASSWORD);
         }
 
-        String token = jwtUtil.createAccessToken(user.getId(), user.getUserRole());
+        String token = jwtUtil.createAccessToken(user.getId(), user.getLoginId(), user.getUserRole());
 
         return new LoginResponse(token);
     }

--- a/src/main/java/com/example/oneplusone/domain/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/oneplusone/domain/common/filter/JwtFilter.java
@@ -1,6 +1,5 @@
 package com.example.oneplusone.domain.common.filter;
 
-import com.example.oneplusone.domain.auth.entity.User;
 import com.example.oneplusone.domain.auth.repository.UserRepository;
 import com.example.oneplusone.domain.common.security.UserDetailsImpl;
 import jakarta.servlet.*;
@@ -11,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
@@ -54,28 +52,18 @@ public class JwtFilter implements Filter {
         String token = jwtUtil.resolveToken(authHeader);
 
         // 토큰 유효성 검증
-        if (!jwtUtil.vaildateToken(token)) {
+        if (!jwtUtil.validateToken(token)) {
             sendError(httpResponse, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다. ");
             return;
         }
 
-        // 토큰에서 사용자ID(식별자) 추출
-        String userIdStr = jwtUtil.extractUserId(token);
-        Long userId;
-
-        try {
-            userId = Long.parseLong(userIdStr);
-        } catch (NumberFormatException e) {
-            sendError(httpResponse, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 사용자 ID");
-            return;
-        }
-
-        // 사용자 정보 DB에서 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        // 토큰에서 userId, loginId, userRole 추출
+        Long userId = Long.parseLong(jwtUtil.extractUserId(token));
+        String loginId = jwtUtil.extractLoginId(token);
+        String userRole = jwtUtil.extractUserRole(token);
 
         // Spring Security 인증 객체 생성 후 등록
-        UserDetailsImpl userDetails = new UserDetailsImpl(user); // 커스텀 UserDetails 구현체
+        UserDetailsImpl userDetails = new UserDetailsImpl(userId, loginId, userRole); // 커스텀 UserDetails 구현체
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -83,7 +71,6 @@ public class JwtFilter implements Filter {
 
         // 전용 API가 아닌 일반 API의 경우
         filterChain.doFilter(servletRequest, servletResponse);
-
 
     }
 

--- a/src/main/java/com/example/oneplusone/domain/common/security/JwtUtil.java
+++ b/src/main/java/com/example/oneplusone/domain/common/security/JwtUtil.java
@@ -33,11 +33,12 @@ public class JwtUtil {
     }
 
     // Access 토큰 생성
-    public String createAccessToken(Long userId, UserRole userRole) {
+    public String createAccessToken(Long userId, String loginId, UserRole userRole) {
         Date now = new Date();
 
         return BEARER_PREFIX + Jwts.builder()
                 .setSubject(String.valueOf(userId)) // 토큰의 주인 (식별자)
+                .claim("loginId", loginId)
                 .claim("auth", userRole.name()) // 권한 저장 ("SELLER" 또는 "BUYER")
                 .setIssuedAt(now) // 발급시간
                 .setExpiration(new Date(now.getTime() + TOKEN_TIME)) // 만료시간 (60분)
@@ -72,6 +73,11 @@ public class JwtUtil {
         return extractAllClaims(token).getSubject();  // JWT의 subject는 생성 시 setSubject(UserId)로 설정한 값
     }
 
+    // JWT 토큰에서 loginId 정보 추출
+    public String extractLoginId(String token) {
+        return extractAllClaims(token).get("loginId", String.class);
+    }
+
     // JWT 토큰에서 권한 정보를 추출하는 메서드
     public String extractUserRole(String token) {
 
@@ -85,7 +91,7 @@ public class JwtUtil {
     }
 
     // jwt 토큰의 유효성 검증
-    public boolean vaildateToken(String token) {
+    public boolean validateToken(String token) {
         try {
             // 1. JWT 파서 객체를 생성하고
             // 2. 서명 검증에 사용할 키를 지정
@@ -121,5 +127,4 @@ public class JwtUtil {
                 .parseClaimsJws(token) // JWT 문자열을 파싱하고 검증
                 .getBody(); // 토큰 본문 (payLoad) 반환
     }
-
 }

--- a/src/main/java/com/example/oneplusone/domain/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/example/oneplusone/domain/common/security/UserDetailsImpl.java
@@ -14,29 +14,30 @@ import java.util.List;
 @Getter
 public class UserDetailsImpl implements UserDetails {
 
-    private final User user;
+    private final Long userId;
+    private final String loginId;
+    private final String userRole;
 
-    public UserDetailsImpl(User user) {
-        this.user = user;
-    }
+    public UserDetailsImpl(Long userId, String loginId, String userRole) {
 
-    public User getUser() {
-        return user;
+        this.userId = userId;
+        this.loginId = loginId;
+        this.userRole = userRole;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userRole));
     }
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return null;
     }
 
     @Override
     public String getUsername() {
-        return user.getLoginId();
+        return loginId;
     }
 
     @Override public boolean isAccountNonExpired() { return true; }


### PR DESCRIPTION
📄 이슈 내용
jwt 토큰 사용시 User 객체를 사용하면서 생기는 보안 취약점 수정

📝 상세 내용
인증객체 생성시 User객체 사용 부분 수정
기존에 토큰 내부에 user객체가 직접 들어가 있던 부분을 수정하였습니다.
user객체 대신 userId, loginId, userRole을 각각 추가하였습니다.
그리고 filter에서 불필요한 사용자 조회를 제거하였습니다.

✅ 체크리스트
- [ ] 오류가 없나요?
- [ ] 코드의 흐름이 잘 작성되어있나요?

코드 흐름에 문제가 없나요?
📍 레퍼런스
[Title](https://.../)