### PR TITLE
feat: 구매 기능 동시성 제어 적용

### DIFF
--- a/src/main/java/com/example/oneplusone/domain/orders/controller/OrderController.java
+++ b/src/main/java/com/example/oneplusone/domain/orders/controller/OrderController.java
@@ -29,4 +29,15 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.ok("상품 구매가 완료되었습니다", order));
     }
+
+    @PostMapping("/orders/lock/products/{productId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> orderProductExclusiveLock(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody OrderRequest orderRequest,
+            @PathVariable Long productId) {
+
+        OrderResponse order = orderService.orderProductExclusiveLock(orderRequest, productId, userDetails.getUserId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("상품 구매가 완료되었습니다", order));
+    }
 }

--- a/src/main/java/com/example/oneplusone/domain/orders/dto/request/OrderRequest.java
+++ b/src/main/java/com/example/oneplusone/domain/orders/dto/request/OrderRequest.java
@@ -1,8 +1,10 @@
 package com.example.oneplusone.domain.orders.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OrderRequest {
     private Long quantity;
 }

--- a/src/main/java/com/example/oneplusone/domain/orders/service/OrderService.java
+++ b/src/main/java/com/example/oneplusone/domain/orders/service/OrderService.java
@@ -24,11 +24,34 @@ public class OrderService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
     private final SearchService searchService;
+
     @Transactional
     public OrderResponse orderProduct(OrderRequest orderRequest, Long productId, Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         Product product = productRepository.findById(productId).orElseThrow(() -> new BaseException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        Long quantity = orderRequest.getQuantity();
+        if (product.getQuantity() < quantity) {
+            throw new BaseException(ErrorCode.PRODUCT_OUT_OF_STOCK);
+        }
+        Long quantityAfter = product.getQuantity() - quantity;
+        product.setQuantity(quantityAfter);
+        // 캐시 동기화가 맞지 않는 상황이기 때문에 캐시를 삭제
+        searchService.cacheEviction(productId);
+
+        Order order = new Order(user, product, quantity);
+        orderRepository.save(order);
+
+        return new OrderResponse(order);
+    }
+
+    @Transactional
+    public OrderResponse orderProductExclusiveLock(OrderRequest orderRequest, Long productId, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        // 배타락 설정
+        Product product = productRepository.findByIdWithExclusiveLock(productId).orElseThrow(() -> new BaseException(ErrorCode.PRODUCT_NOT_FOUND));
 
         Long quantity = orderRequest.getQuantity();
         if (product.getQuantity() < quantity) {

--- a/src/main/java/com/example/oneplusone/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/oneplusone/domain/product/repository/ProductRepository.java
@@ -1,10 +1,14 @@
 package com.example.oneplusone.domain.product.repository;
 
 import com.example.oneplusone.domain.product.entity.Product;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("""
@@ -12,4 +16,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
         WHERE (:search IS NULL OR p.name LIKE CONCAT('%', :search, '%'))
     """)
     Page<Product> findByProduct(String search, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdWithExclusiveLock(Long id);
 }

--- a/src/test/java/com/example/oneplusone/domain/order/service/BaseOrderTest.java
+++ b/src/test/java/com/example/oneplusone/domain/order/service/BaseOrderTest.java
@@ -1,0 +1,78 @@
+package com.example.oneplusone.domain.order.service;
+
+import com.example.oneplusone.domain.auth.controller.dto.LoginRequest;
+import com.example.oneplusone.domain.auth.entity.User;
+import com.example.oneplusone.domain.auth.enums.UserRole;
+import com.example.oneplusone.domain.auth.repository.UserRepository;
+import com.example.oneplusone.domain.orders.dto.request.OrderRequest;
+import com.example.oneplusone.domain.product.entity.Product;
+import com.example.oneplusone.domain.product.repository.ProductRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BaseOrderTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ProductRepository productRepository;
+
+    // 데이터 생성
+    protected User getUser(String uniqueLoginId) {
+        User user = new User("nickname", uniqueLoginId, passwordEncoder.encode("password"), UserRole.SELLER);
+        userRepository.save(user);
+        return user;
+    }
+
+    protected Product getProduct(String uniqueLoginId) {
+        User user = getUser(uniqueLoginId);
+
+        Product product = new Product("ProductName", "type", 1000L, 100L, user);
+        productRepository.save(product);
+        return product;
+    }
+
+    // 토큰
+    protected String getTokenByLogin(String loginId) throws Exception {
+        LoginRequest request = new LoginRequest(loginId, "password");
+
+        String signupAsString = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return objectMapper.readTree(signupAsString)
+                .get("data")
+                .get("token")
+                .asText();
+    }
+
+    // 테스트할 메서드에서 상태코드 가져오기
+    protected int getStatusOrderProduct(Long productId, String token, OrderRequest orderRequest, String url) throws Exception {
+        return mockMvc.perform(post(url, productId)
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderRequest)))
+                .andReturn()
+                .getResponse()
+                .getStatus();
+    }
+}

--- a/src/test/java/com/example/oneplusone/domain/order/service/OrderProductTest.java
+++ b/src/test/java/com/example/oneplusone/domain/order/service/OrderProductTest.java
@@ -1,0 +1,92 @@
+package com.example.oneplusone.domain.order.service;
+
+import com.example.oneplusone.domain.common.exception.BaseException;
+import com.example.oneplusone.domain.common.exception.ErrorCode;
+import com.example.oneplusone.domain.orders.dto.request.OrderRequest;
+import com.example.oneplusone.domain.product.entity.Product;
+import com.example.oneplusone.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class OrderProductTest extends BaseOrderTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    private final AtomicInteger successCount = new AtomicInteger();
+    private final AtomicInteger failCount = new AtomicInteger();
+
+    @Test
+    protected void 락이_없는_테스트_orderProduct() throws Exception {
+        String url = "/orders/products/{productId}";
+
+        Product findProduct = orderProductTest(url);
+
+        assertThat(successCount.get()).isLessThan(100);
+        assertThat(failCount.get()).isGreaterThan(0);
+        assertThat(findProduct.getQuantity()).isGreaterThan(0);
+    }
+
+    @Test
+    protected void 배타락이_적용된_테스트_orderProduct() throws Exception {
+        String url = "/orders/lock/products/{productId}";
+
+        Product findProduct = orderProductTest(url);
+
+        assertThat(successCount.get()).isEqualTo(100);
+        assertThat(failCount.get()).isEqualTo(0);
+        assertThat(findProduct.getQuantity()).isEqualTo(0);
+    }
+
+    protected Product orderProductTest(String url) throws Exception {
+        // given
+        // 필요 데이터 생성
+        OrderRequest orderRequest = new OrderRequest(1L);
+        String uniqueLoginId = "loginId_" + System.currentTimeMillis();
+        Long productId = getProduct(uniqueLoginId).getId();
+        String token = getTokenByLogin(uniqueLoginId);
+
+        // 멀티 쓰레드 설정
+        int size = 100;
+        int threadPoolSize = Runtime.getRuntime().availableProcessors();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadPoolSize);
+        CountDownLatch latch = new CountDownLatch(size);
+
+        // when
+        for (int i = 0; i < size; i++) {
+            executor.submit(() -> {
+                try {
+                    int status = getStatusOrderProduct(productId, token, orderRequest, url);
+                    if (status == 201) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        // 모든 작업이 완료될 때까지 대기
+        latch.await();
+        executor.shutdown();
+
+        // then
+        return productRepository.findById(productId).orElseThrow(() -> new BaseException(ErrorCode.PRODUCT_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
- 동시성 제어를 적용한 새로운 api
  - /orders/lock/products/{productId}
- product 조회시, 배타락 적용
  - findByIdWithExclusiveLock
  - Lock(LockModeType.PESSIMISTIC_WRITE) 사용

테스트 수행
- BaseOrderTest : 테스트 수행을 위한 기본 설정
  - getTokenByLogin : 로그인으로 토큰 얻기
  - getProduct : 상품 생성
  - getUser : 유저 생성
- orderProductTest : 테스트 로직
  - 테스트를 위해 OrderRequest 생성자 추가
- 락이_없는_테스트_orderProduct()
  - 일부 실패를 기대함
- 배타락이_적용된_테스트_orderProduct()
  - 모두 성공을 기대함